### PR TITLE
Allow the http client to be overridden

### DIFF
--- a/client.go
+++ b/client.go
@@ -51,6 +51,11 @@ func (c *Client) CustomEndpoint(e string) {
 	c.Endpoint = e
 }
 
+// CustomHTTPClient overrides the default http.Client that the client uses
+func (c *Client) CustomHTTPClient(httpClient *http.Client) {
+	c.httpClient = httpClient
+}
+
 // EnableDebug logs debugging info from the API calls
 func (c *Client) EnableDebug() {
 	c.Debug = true


### PR DESCRIPTION
This might be generally useful to allow clients to have a specific timeout or whatever, but the specific reason I wanted it was to have a custom transport so that I could inject the necessary headers to bypass authentication and target the backend services in the dev environment.